### PR TITLE
Fix issue with handling only one photo

### DIFF
--- a/src/components/PhotoMap.tsx
+++ b/src/components/PhotoMap.tsx
@@ -2,14 +2,12 @@ import * as React from "react";
 import styled from "styled-components";
 import { Map as LMap, TileLayer, Marker } from "react-leaflet";
 import { path, isEmpty } from "ramda";
-import { FitBoundsOptions } from "leaflet";
 import { Redirect } from "react-router-dom";
 
 import { Photo } from "types/api";
 import ImagePopup from "components/ImagePopup";
-import { getBounds } from "utils/map";
-import { getLocations } from "utils/photos";
 import { AuthContext, PhotoContext } from "store";
+import { getLeafletProps } from "utils/map";
 
 const LeafletMap = styled(LMap)`
   flex: 1;
@@ -47,11 +45,8 @@ const PhotoMap: React.FC = () => {
     return <Redirect to="/" />;
   }
 
-  const bounds = getBounds(getLocations(photos));
-  const boundsOptions: FitBoundsOptions = { padding: [45, 45] };
-
   return (
-    <LeafletMap {...{ bounds, boundsOptions }}>
+    <LeafletMap {...getLeafletProps(photos)}>
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       <PlotPhotos {...{ photos }} />
     </LeafletMap>

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,6 +1,10 @@
+import { FitBoundsOptions } from "leaflet";
 import { pluck } from "ramda";
+import { MapProps } from "react-leaflet";
 
+import { Photo } from "types/api";
 import { Location } from "types/map";
+import { getLocations } from "./photos";
 
 const maxReducer = (acc: number | null, next: number) =>
   acc ? (next > acc ? next : acc) : next;
@@ -24,3 +28,12 @@ export const getBounds = (locations: Location[]) => {
   }
   return undefined;
 };
+
+export const getLeafletProps = (photos: Photo[]): Partial<MapProps> => {
+  const locations = getLocations(photos);
+
+  const bounds = getBounds(locations);
+  const boundsOptions: FitBoundsOptions = { padding: [45, 45] };
+
+  return {bounds, boundsOptions}
+}

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -31,6 +31,11 @@ export const getBounds = (locations: Location[]) => {
 
 export const getLeafletProps = (photos: Photo[]): Partial<MapProps> => {
   const locations = getLocations(photos);
+  const oneLocation = locations.length === 1 ? locations[0] : undefined;
+
+  if (oneLocation) {
+    return {center: oneLocation, zoom: 12};
+  }
 
   const bounds = getBounds(locations);
   const boundsOptions: FitBoundsOptions = { padding: [45, 45] };


### PR DESCRIPTION
### Description
Calling `getBounds` when there is only one photo with a location would break the rendering of the map.

These changes use the one location as the center of the map instead of attempting to get bounds.